### PR TITLE
Updated gwt version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ http://maven.apache.org/maven-v4_0_0.xsd">
     </modules>
 
     <properties>
-        <gwtVersion>2.5.0</gwtVersion>
+        <gwtVersion>2.7.0</gwtVersion>
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.webport>8082</tomcat.webport>
@@ -62,11 +62,14 @@ http://maven.apache.org/maven-v4_0_0.xsd">
 
 
     <build>
+    
+        <defaultGoal>clean install  tomcat7:run-war-only</defaultGoal>
+    
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.0-rc2</version>
+                <version>${gwtVersion}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -78,8 +81,8 @@ http://maven.apache.org/maven-v4_0_0.xsd">
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Updated the gwt and added defaultGoal to the build so the user/developer can just run "mvn" and get the project built and running . In this GWT version it have super dev mode which can solve problem with browsers & its plugins for debug/dev, but you will also need to start using "mvn gwt:run -pl web"